### PR TITLE
Add `<figure>` recipe

### DIFF
--- a/src/_data/snippets.js
+++ b/src/_data/snippets.js
@@ -8,6 +8,7 @@ module.exports = [
   "hero-article",
   "blockquote",
   "article",
+  "figure",
   "card-grid",
   "contact-form",
   "footer",

--- a/src/snippets/figure.njk
+++ b/src/snippets/figure.njk
@@ -10,7 +10,7 @@ templateEngineOverride: md, njk
 {%- set html -%}
 <figure>
   <img src="https://source.unsplash.com/400x300/?dinosaur" alt="" width="400" height="300">
-  <figcaption>A stock image of a dinosaur</figcaption>
+  <figcaption>Lorem ipsum dolor sit.</figcaption>
 </figure>
 {%- endset -%}
 {% include "code.njk" %}

--- a/src/snippets/figure.njk
+++ b/src/snippets/figure.njk
@@ -1,0 +1,16 @@
+---
+title: Figure
+contributorsName: Michael W. Delaney
+contributorsURL: https://michaeldelaney.me
+templateEngineOverride: md, njk
+---
+{% set description %}
+  Usually a `<figure>` is an image, illustration, diagram, code snippet, etc. If your use case doesn't require a caption, the `<figcaption>` can be omitted.
+{% endset %}
+{%- set html -%}
+<figure>
+  <img src="https://source.unsplash.com/400x300/?dinosaur" alt="" width="400" height="300">
+  <figcaption>A stock image of a dinosaur</figcaption>
+</figure>
+{%- endset -%}
+{% include "code.njk" %}

--- a/src/snippets/figure.njk
+++ b/src/snippets/figure.njk
@@ -5,12 +5,16 @@ contributorsURL: https://michaeldelaney.me
 templateEngineOverride: md, njk
 ---
 {% set description %}
-  Usually a `<figure>` is an image, illustration, diagram, code snippet, etc. If your use case doesn't require a caption, the `<figcaption>` can be omitted.
+  Usually a an image, illustration, diagram, code snippet, etc. Read about the `<figure>` tag and its uses <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure">here at <abbr title="Mozilla Developer Network">MDN</abbr></a>. If your use case doesn't require a caption, the `<figcaption>` can be omitted.
+
+  Writing separate content for the `<figcaption>` element and the image's _alt_ attribute can be a confusing. Generally speaking the _alt_ attribute should describe the contents of the picture, while the `<figcaption>` element's purpose can vary depending on the nature of the `<figure>` it's captioning.
+
+  Read about how to write `<figcaption>` and _alt_ text in an assistive and accessible way in [Elaina Natario's article "Alt vs Figcaption"](https://thoughtbot.com/blog/alt-vs-figcaption).
 {% endset %}
 {%- set html -%}
 <figure>
   <img src="https://source.unsplash.com/400x300/?dinosaur" alt="" width="400" height="300">
-  <figcaption>A stock image of a dinosaur</figcaption>
+  <figcaption>Lorem ipsum dolor sit.</figcaption>
 </figure>
 {%- endset -%}
 {% include "code.njk" %}


### PR DESCRIPTION
Added `<figure>` recipe with a single image and caption. The `<figure>` section could be expanded to include other content examples, like code snippets, poems, etc. but this basic example is the best place to start.

Here's what it looks like:

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/2457670/127528404-66568f6b-6468-4469-9c3e-9823f8d1395b.png">
