### PR TITLE
Updates the faq section classname in _demo.scss

### DIFF
--- a/src/sass/_demos.scss
+++ b/src/sass/_demos.scss
@@ -98,7 +98,7 @@
   }
 }
 
-.demo-faq-section {
+.demo-collapsible-faqs {
   details{
     & + details {
       margin-top: 1rem;


### PR DESCRIPTION
I realized that since the title of the FAQ section was updated, the class also needed to be updated in _demo.scss. Hence, there is no styling applied current on the FAQ section. This PR should fix that.